### PR TITLE
Add missing requirements

### DIFF
--- a/shell/bootstrap.sh
+++ b/shell/bootstrap.sh
@@ -26,6 +26,8 @@ check_prereq() {
     fi
 }
 check_prereq cc
+check_prereq c++
+check_prereq diff
 check_prereq make
 check_prereq wget curl
 check_prereq patch


### PR DESCRIPTION
Thanks for the patch, it helped me install a bundle successfully.

I'd just add two extra lines, since otherwise the build may fail later.

- About the `c++` check, I believe it should be more standard than `g++`, but maybe there are systems where it could fail;
- The `diff` check is unnecessary in practice for most people, but when running inside a Docker image, it is necessary (I believe `dune` uses it later), so better check it early than fail later during the build.